### PR TITLE
Fix Clarity radio & checkbox .isDisabled()

### DIFF
--- a/src/main/java/at/porscheinformatik/seleniumcomponents/clarity/ClarityCheckboxComponent.java
+++ b/src/main/java/at/porscheinformatik/seleniumcomponents/clarity/ClarityCheckboxComponent.java
@@ -62,6 +62,24 @@ public class ClarityCheckboxComponent extends AbstractSeleniumComponent implemen
         }
     }
 
+    @Override
+    public boolean isEnabled()
+    {
+        return checkbox.isEnabled();
+    }
+
+    @Override
+    public boolean isEditable()
+    {
+        return checkbox.isEditable();
+    }
+
+    @Override
+    public boolean isDisabled()
+    {
+        return checkbox.isDisabled();
+    }
+
     public String getId()
     {
         return checkbox.getId();

--- a/src/main/java/at/porscheinformatik/seleniumcomponents/clarity/ClarityRadioComponent.java
+++ b/src/main/java/at/porscheinformatik/seleniumcomponents/clarity/ClarityRadioComponent.java
@@ -58,4 +58,22 @@ public class ClarityRadioComponent extends AbstractSeleniumComponent implements 
             label.click();
         }
     }
+
+    @Override
+    public boolean isEnabled()
+    {
+        return radio.isEnabled();
+    }
+
+    @Override
+    public boolean isEditable()
+    {
+        return radio.isEditable();
+    }
+
+    @Override
+    public boolean isDisabled()
+    {
+        return radio.isDisabled();
+    }
 }


### PR DESCRIPTION
When checking a Clarity radio or checkbox input for whether it was
disabled in an IT, it would return the disabled attribute of the
WRAPPER element, not the input element itself.

This was fixed by overriding the .isDisabled() method, and others.

Quite interesting that this error was never noticed before.