### PR TITLE
Fix clarity checkbox getName()

### DIFF
--- a/src/main/java/at/porscheinformatik/seleniumcomponents/clarity/ClarityCheckboxComponent.java
+++ b/src/main/java/at/porscheinformatik/seleniumcomponents/clarity/ClarityCheckboxComponent.java
@@ -9,6 +9,7 @@ import at.porscheinformatik.seleniumcomponents.AbstractSeleniumComponent;
 import at.porscheinformatik.seleniumcomponents.ActiveSeleniumComponent;
 import at.porscheinformatik.seleniumcomponents.SeleniumComponent;
 import at.porscheinformatik.seleniumcomponents.SeleniumUtils;
+import at.porscheinformatik.seleniumcomponents.Utils;
 import at.porscheinformatik.seleniumcomponents.WebElementSelector;
 import at.porscheinformatik.seleniumcomponents.component.CheckboxComponent;
 import at.porscheinformatik.seleniumcomponents.component.HtmlComponent;
@@ -89,7 +90,7 @@ public class ClarityCheckboxComponent extends AbstractSeleniumComponent implemen
     {
         String name = checkbox.getName();
 
-        if (name == null)
+        if (Utils.isEmpty(name))
         {
             name = SeleniumUtils.getAttribute(checkbox, "ng-reflect-name");
         }


### PR DESCRIPTION
This was breaking an IT as the name would not be `null` but an empty String (`""`), so the `if` clause was never entered.

This was fixed.