### PR TITLE
Fix empty String parse error for parseDate()

### DIFF
--- a/src/main/java/at/porscheinformatik/seleniumcomponents/SeleniumEnvironment.java
+++ b/src/main/java/at/porscheinformatik/seleniumcomponents/SeleniumEnvironment.java
@@ -88,9 +88,10 @@ public interface SeleniumEnvironment
             // failed to take screenshot because window has been closed already
             return null;
         }
-        catch (Exception e) {
+        catch (Exception e)
+        {
             LOG.warn("Failed to take screenshot", e);
-            
+
             return null;
         }
     }
@@ -192,7 +193,7 @@ public interface SeleniumEnvironment
      */
     default LocalDate parseDate(String dateAsString, FormatStyle style)
     {
-        if (dateAsString == null)
+        if (dateAsString == null || dateAsString.trim().length() == 0)
         {
             return null;
         }


### PR DESCRIPTION
If the String is empty instead of null, which can happen with a date
input field which is left empty, the method throws a parse error.
Fixed this.