### PR TITLE
Add method to reflect disabled state in ClarityInputContainerComponent

### DIFF
--- a/src/main/java/at/porscheinformatik/seleniumcomponents/clarity/ClarityInputContainerComponent.java
+++ b/src/main/java/at/porscheinformatik/seleniumcomponents/clarity/ClarityInputContainerComponent.java
@@ -2,11 +2,13 @@ package at.porscheinformatik.seleniumcomponents.clarity;
 
 import static at.porscheinformatik.seleniumcomponents.WebElementSelector.*;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 
 import at.porscheinformatik.seleniumcomponents.SeleniumComponent;
 import at.porscheinformatik.seleniumcomponents.WebElementSelector;
 import at.porscheinformatik.seleniumcomponents.component.InputComponent;
+import org.openqa.selenium.NoSuchElementException;
 
 public class ClarityInputContainerComponent extends ClarityFormControlContainer
 {
@@ -70,4 +72,14 @@ public class ClarityInputContainerComponent extends ClarityFormControlContainer
         // Mark the whole input text and delete it
         input.sendKeys(Keys.chord(Keys.CONTROL, "A"), Keys.BACK_SPACE);
     }
+
+    /**
+     * Use this method to check whether or not you can write a new value to the input control.
+     * @return true if the input control has been disabled, and true otherwise
+     */
+    public boolean isDisabled()
+    {
+        return input.isDisabled();
+    }
+
 }


### PR DESCRIPTION
# Background 

When setting a new value in the input control using this component, you receive an RuntimeException that you cannot anticipate as a user.

# PR Includes

In this PR we add a new method to the implementation of this component that can be used by users to test the state of the input control, and whether or not it's disabled

# Suggestion

Should call this method before writing a new value to the input control? Cauz otherwise, the exception still occurs.