### PR TITLE
Add method to clear combobox and mark it dirty

### DIFF
--- a/src/main/java/at/porscheinformatik/seleniumcomponents/clarity/ClaritySingleSelectComboboxComponent.java
+++ b/src/main/java/at/porscheinformatik/seleniumcomponents/clarity/ClaritySingleSelectComboboxComponent.java
@@ -2,6 +2,8 @@ package at.porscheinformatik.seleniumcomponents.clarity;
 
 import static at.porscheinformatik.seleniumcomponents.WebElementSelector.*;
 
+import org.openqa.selenium.Keys;
+
 import at.porscheinformatik.seleniumcomponents.SeleniumComponent;
 import at.porscheinformatik.seleniumcomponents.SeleniumComponentFactory;
 import at.porscheinformatik.seleniumcomponents.WebElementSelector;
@@ -25,12 +27,20 @@ public class ClaritySingleSelectComboboxComponent<OPTION_TYPE extends AbstractCl
         super(parent, selector, optionFactory);
     }
 
-    // ---
+    // --- //
 
     @Override
     public void clear()
     {
         input.clear();
+    }
+
+    public void clearAndMarkDirty()
+    {
+        input.clear();
+
+        // we need to do this here or the formControl will not recognize the value having changed
+        input.sendKeys(".", Keys.BACK_SPACE);
     }
 
     public String getSelectedLabel()


### PR DESCRIPTION
Calling only `input.clear()` does not update the formControl, it is still considered "PRISTINE" and the value remains the previous one.

So we need to simulate deleting the content of the combobox to truly update the formControl to being "DIRTY".