### PR TITLE
Create `ActiveSeleniumComponent#isInteractable`

### DIFF
--- a/src/main/java/at/porscheinformatik/seleniumcomponents/ActiveSeleniumComponent.java
+++ b/src/main/java/at/porscheinformatik/seleniumcomponents/ActiveSeleniumComponent.java
@@ -1,7 +1,8 @@
 package at.porscheinformatik.seleniumcomponents;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
 
+import org.openqa.selenium.Dimension;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
@@ -13,6 +14,33 @@ import org.openqa.selenium.WebElement;
  */
 public interface ActiveSeleniumComponent extends SeleniumComponent
 {
+    /**
+     * Returns true if the component has a size that can be interacted with. Necessary for preventing
+     * `ElementNotInteractableException: element not interactable: element has zero size` errors.
+     * 
+     * @return True if the element has a size that can be interacted with.
+     */
+    default boolean isInteractable() {
+        try {
+            return SeleniumUtils.retryOnStale(() -> {
+                Dimension size = element().getSize();
+                int width = size.getWidth();
+                int height = size.getHeight();
+
+                if (width == 0 || height == 0) {
+                    LOG.error("Element %s has size %dw x %dh. This is not interactable.", describe(), width, height);
+                    return false;
+                }
+
+                return true;
+            });
+        }
+        catch (NoSuchElementException e)
+        {
+            return false;
+        }
+    }
+
     /**
      * Returns true if the component is enabled.
      *

--- a/src/main/java/at/porscheinformatik/seleniumcomponents/clarity/ClarityCheckboxComponent.java
+++ b/src/main/java/at/porscheinformatik/seleniumcomponents/clarity/ClarityCheckboxComponent.java
@@ -82,7 +82,7 @@ public class ClarityCheckboxComponent extends AbstractSeleniumComponent implemen
         {
             LOG.interaction("Selecting %s", describe());
 
-            if (label.isClickable())
+            if (label.isInteractable() && label.isClickable())
             {
                 label.click();
             }
@@ -104,7 +104,7 @@ public class ClarityCheckboxComponent extends AbstractSeleniumComponent implemen
         {
             LOG.interaction("Unselecting %s", describe());
 
-            if (label.isClickable())
+            if (label.isInteractable() && label.isClickable())
             {
                 label.click();
             }


### PR DESCRIPTION
Reason for this change is that around v7.10, Clarity changed the size of empty checkbox label tags: while previously they had a padding that caused them to be size a * b, even without any content, the padding was now removed and the resulting size is 0 * b. This causes an `ElementNotInteractableException: element not interactable: element has zero size` when Selenium attempts to click on the label.

So a method was added to be able to check if the element can be interacted with before the interaction is attempted.

(I would have made this part of the #isVisible or #isClickable method, but that causes unsolvable problems with selecting `<option>`s in the `SelectComponent`.)